### PR TITLE
fixes #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,6 @@ optimal throughput:
 ```bash
 samtools view -h some.bam|streammd|samtools view -@2 -o some.MD.bam
 ```
-
-### History
-
-`streammd` version 4.0 is a complete rewrite in C++.
-
 ### Citing
 
 Please cite https://doi.org/10.1101/2022.10.12.511997 when referring to `streammd` in publications.

--- a/src/markdups.cxx
+++ b/src/markdups.cxx
@@ -194,27 +194,24 @@ void write_metrics(std::string metricsfname, metrics metrics) {
   spdlog::info("templates marked duplicate: {}", metrics.templates_marked_duplicate);
   spdlog::info("template duplicate fraction: {:.4f}", dup_frac);
 
-  // std::format doesn't arrive till c++20 so format file output with ye olde
-  // fprintf. Note that spdlog includes fmt lib but using that would tie us to
-  // spdlog for logging.
-  FILE* metricsf { fopen(metricsfname.c_str(), "w") };
-  if (nullptr == metricsf) {
+  std::ofstream metricsf;
+  metricsf.open(metricsfname);
+  if (!metricsf) {
     throw std::runtime_error(metricsfname + " cannot be opened for writing");
-  } else {
-    fprintf(metricsf,
-        "{"
-          "\"ALIGNMENTS\":%lu,"
-          "\"ALIGNMENTS_MARKED_DUPLICATE\":%lu,"
-          "\"TEMPLATES\":%lu,"
-          "\"TEMPLATES_MARKED_DUPLICATE\":%lu,"
-          "\"TEMPLATE_DUPLICATE_FRACTION\":%0.4f"
-        "}",
-        metrics.alignments,
-        metrics.alignments_marked_duplicate,
-        metrics.templates,
-        metrics.templates_marked_duplicate,
-        dup_frac);
   }
+  metricsf << fmt::format(
+    "{{"
+      "\"ALIGNMENTS\":{},"
+      "\"ALIGNMENTS_MARKED_DUPLICATE\":{},"
+      "\"TEMPLATES\":{},"
+      "\"TEMPLATES_MARKED_DUPLICATE\":{},"
+      "\"TEMPLATE_DUPLICATE_FRACTION\":{:.4f}"
+    "}}", 
+    metrics.alignments,
+    metrics.alignments_marked_duplicate,
+    metrics.templates,
+    metrics.templates_marked_duplicate,
+    dup_frac);
 }
 
 }

--- a/src/markdups.h
+++ b/src/markdups.h
@@ -26,6 +26,8 @@ const uint32_t log_interval { 1000000 };
 const std::regex re_pgid { R"(\tID:([^\t]+))" };
 const std::string pgid { "streammd"  };
 const std::string pgtag { "PG:Z:" };
+const std::string _pgtag { SAM_delimiter + pgtag };
+const std::string pgtagval { _pgtag + pgid };
 const std::string unmapped { DEL };
 
 struct metrics {
@@ -81,7 +83,7 @@ class SamRecord {
     cigarlen_ = stop - start;
 
     // pg
-    start=stop+1; stop=buffer.find(pgtag_, start);
+    start=stop+1; stop=buffer.find(_pgtag, start);
     if (stop == std::string::npos) {
       pgidx_ = buffer.length();
       pglen_ = 0;
@@ -151,14 +153,12 @@ class SamRecord {
     if (flag_ != prev) {
       // update the buffer from the end (PG first then FLAG) so the parsed idx
       // values are valid this one time.
-      buffer.replace(pgidx_, pglen_, pgtagval_);
+      buffer.replace(pgidx_, pglen_, pgtagval);
       buffer.replace(flagidx_, flaglen_, fmt::format_int(flag_).c_str());
     }
   }
 
  private:
-  inline static const std::string pgtag_ { std::string(1, SAM_delimiter) + pgtag };
-  inline static const std::string pgtagval_ { pgtag_ + pgid };
   std::string qname_;
   size_t flagidx_;
   size_t flaglen_;

--- a/src/streammd.cxx
+++ b/src/streammd.cxx
@@ -114,16 +114,14 @@ int main(int argc, char* argv[]) {
         infname ? [&]() -> std::istream& {
           inf.open(*infname);
           if (!inf) {
-            std::string errmsg { *infname + " cannot be opened for reading" };
-            throw std::runtime_error(errmsg);
+            throw std::runtime_error(*infname + " cannot be opened for reading");
           }
           return inf;
         }() : std::cin,
         outfname ? [&]() -> std::ostream& {
           outf.open(*outfname);
           if (!outf) {
-            std::string errmsg { *outfname + " cannot be opened for writing" };
-            throw std::runtime_error(errmsg);
+            throw std::runtime_error(*outfname + " cannot be opened for writing");
           }
           return outf;
         }() : std::cout,

--- a/tests/test_markdups.cxx
+++ b/tests/test_markdups.cxx
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <fstream>
+#include <map>
+#include <sstream>
 #include "markdups.h"
 #include "version.h"
 


### PR DESCRIPTION
It seems GCC and Clang differ on how inline static vars are initialized.
https://github.com/llvm/llvm-project/issues/55804
Long story short, this is a workaround. Now `_pgtag` and `pgtagval` aren't `SamRecord` members any longer and they're clearly initialized before everything.